### PR TITLE
Script now exits on SIGINT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+run: build
+	docker run -e "APIKEY=none" -e "RECORD_LIST=test" -e "DOMAIN=notavalid.domain" gandi-livedns:snapshot
+
+run:
+	docker build -t gandi-livedns:snapshot .

--- a/run.sh
+++ b/run.sh
@@ -12,5 +12,5 @@ while true; do
   if [ "${SET_IPV6}" = 'yes' ] ; then
     update_ipv6.sh
   fi
-  sleep ${REFRESH_INTERVAL}
+  sleep ${REFRESH_INTERVAL} & wait
 done


### PR DESCRIPTION
Restarting jbbodart/gandi-livedns currently requires SIGKILL, this change allows a simple SIGINT to work
I'm using this project in docker-compose context and currently restarting my stack hangs for a bit due to this. Would greatly appreciate if you could publish with this change.

Also added Makefile for build/test convenience. Arguable convenience.